### PR TITLE
fix an issue where PI keywords were not recognized

### DIFF
--- a/src/calculator/Form.java
+++ b/src/calculator/Form.java
@@ -186,6 +186,17 @@ public class Form {
 				}
 			}
 			if (bag.matches(operator)) {
+                if (bag.equals("P")) {
+                    try {
+                        bag = pack(bag);
+                        if (!bag.equals("PI")) {
+                            bag = bag.substring(0, bag.length() - 1);
+                            pos--;
+                        }
+                    } catch(StringIndexOutOfBoundsException e) {
+
+                    }
+                }
 				splittedForm.add(bag);
 				entity.add(new Num(0));
 				bag = "";


### PR DESCRIPTION
Pキーワードを先に解決する問題を修正。
Pキーワードを読むと、次の文字を取得してその文字列がPIならばPIキーワードとして扱う。
fix #1